### PR TITLE
Add an "access token" report URL to webhook payloads

### DIFF
--- a/docs/webhooks/index.html
+++ b/docs/webhooks/index.html
@@ -269,6 +269,7 @@
     maxScore: number,
     plagiarismLevel: number,
     plagiarismLabel: 'none' | 'low' | 'medium' | 'high' | '-',
+    url: string,
   }
 };</code></pre>
                     <div>Sample request:</div>
@@ -286,6 +287,7 @@
     maxScore: 1000,
     plagiarismLevel: 0.5,
     plagiarismLabel: 'medium',
+    url: https://app.codesignal.com/test-result/oH3qeBC38oFsf7qB4?accessToken=A7HnBpab4aD7xm7Kp-iPhk2se5Wnxeg7x9GruANLzn
   }
 };</code></pre>
                 </div>
@@ -309,7 +311,8 @@
       score: number,
       maxScore: number,
       duration: number,
-      id: string
+      id: string,
+      url: string,
     }>
   }
 };</code></pre>
@@ -328,13 +331,15 @@
       score: 1148,
       maxScore: 1300,
       duration: 5045173,
-      id: '272bu5Na997EdzmQ8'
+      id: '272bu5Na997EdzmQ8',
+      url: https://app.codesignal.com/coding-report/8rRHAnRb3mW6RSfJG-a7RFoj2CESoWCji588zCnDJy/J3y6nqx6C89oMq998?accessToken=5ejNbPLLD79xFGNuQ-cEq43zQPQrQqkg2cn3danTag,
     }, {
       codingScore: 793,
       score: 876,
       maxScore: 1300,
       duration: 5286253,
-      id: '2TgbrRMkBiksAXqEd'
+      id: '2TgbrRMkBiksAXqEd',
+      url: https://app.codesignal.com/coding-report/8rRHAnRb3mW6RSfJG-a7RFoj2CESoWCji588zCnDJy/J3y6nqx6C89oMq998?accessToken=5ejNbPLLD79xFGNuQ-cEq43zQPQrQqkg2cn3danTag,
     }]
   }
 };</code></pre>


### PR DESCRIPTION
1. Add `url` to `companyTestSessionFinished` event's payload.
1. Add `url` to each `sharedTestSessions` in `certificationResultShared` event's payload.