### PR TITLE
Describe the two new webhook types

### DIFF
--- a/docs/webhooks/index.html
+++ b/docs/webhooks/index.html
@@ -222,7 +222,7 @@
                 <div class="subsection">
                     <h3>companyTestSessionStarted</h3>
                     <p>
-                        Fired when a candidate starts a test.
+                        Fired when a candidate starts a test session.
                     </p>
                     <div>Request format:</div>
                     <pre><code>{
@@ -252,7 +252,7 @@
                 <div class="subsection">
                     <h3>companyTestSessionFinished</h3>
                     <p>
-                        Fired when a candidate finishes the test, or the test gets force-finished because the time runs out.
+                        Fired when a candidate finishes the test session (including if the session gets force-finished because the time runs out).
                     </p>
                     <div>Request format:</div>
                     <pre><code>{
@@ -288,6 +288,82 @@
     plagiarismLevel: 0.5,
     plagiarismLabel: 'medium',
     url: https://app.codesignal.com/test-result/oH3qeBC38oFsf7qB4?accessToken=A7HnBpab4aD7xm7Kp-iPhk2se5Wnxeg7x9GruANLzn
+  }
+};</code></pre>
+                </div>
+                <div class="subsection">
+                    <h3>certificationResultPending</h3>
+                    <p>
+                        Fired when a candidate finishes a standardized test session, if that session has been autoshared with your company.
+                        The certification request is still pending and has not yet been certified by the CodeSignal certification team.
+                    </p>
+                    <div>Request format:</div>
+                    <pre><code>{
+  event: 'certificationResultPending',
+  triggeredOn: number,
+  payload: {
+    certificationRequestId: string,
+    testSessionId: string,
+    testId: string,
+    testTitle: string,
+    candidateEmail: string,
+    candidateName: string,
+    duration: number, // milliseconds
+    score: number,
+    maxScore: number,
+    codingScore: number,
+  }
+};</code></pre>
+                    <div>Sample request:</div>
+                    <pre><code>{
+  event: 'certificationResultPending',
+  triggeredOn: 1553720789347,
+  payload: {
+    certificationRequestId: 'lehjeh36dleh29',
+    testSessionId: '2TgbrRMkBiksAXqEd',
+    testId: 'dhey29hcl28hl28',
+    testTitle: 'General Coding Assessment',
+    candidateEmail: 'john.doe@gmail.com',
+    candidateName: 'John Doe',
+    duration: 5286253,
+    score: 876,
+    maxScore: 1300,
+    codingScore: 793
+  }
+};</code></pre>
+                </div>
+                <div class="subsection">
+                    <h3>certificationResultNotCertified</h3>
+                    <p>
+                        Fired when a candidate's standardized test session is denied certification by the CodeSignal certification team,
+                        if that test session has been autoshared with your company. The certification request will remain open even after this,
+                        in case of retakes or technical issues, so receiving this webhook is not "final" -- you may subsequently receive a <strong>certificationResultShared</strong>
+                        or <strong>certificationRequestExpired</strong> event.
+                    </p>
+                    <div>Request format:</div>
+                    <pre><code>{
+  event: 'certificationResultNotCertified',
+  triggeredOn: number,
+  payload: {
+    certificationRequestId: string,
+    testId: string,
+    testTitle: string,
+    candidateEmail: string,
+    candidateName: string,
+    rejectedReasons: Array&lt;string&gt;
+  }
+};</code></pre>
+                    <div>Sample request:</div>
+                    <pre><code>{
+  event: 'certificationResultNotCertified',
+  triggeredOn: 1553720789347,
+  payload: {
+    certificationRequestId: 'lehjeh36dleh29',
+    testId: 'dhey29hcl28hl28',
+    testTitle: 'General Coding Assessment',
+    candidateEmail: 'john.doe@gmail.com',
+    candidateName: 'John Doe',
+    rejectedReasons: ['Unauthorized resource', 'Presence of others']
   }
 };</code></pre>
                 </div>


### PR DESCRIPTION
Closes #19.

I added two sub-sections to the webhook documentation page that describe the new `certificationResultPending` and `certificationResultNotCertified` webhook events, including a description of when they fire, the payload's shape, and a sample payload for each.

To review: You can simply review what I wrote in the HTML directly! If you'd like to preview how it looks in the site, check out my branch and then run `npm start` to host the documentation site locally (more about this in the README), or just open `docs/index.html` and browse directly since it's a static site.

Shouldn't be merged until changes are actually deployed on production later this week.