### PR TITLE
versionedCodinScore field in webhooks

### DIFF
--- a/docs/webhooks/index.html
+++ b/docs/webhooks/index.html
@@ -46,6 +46,12 @@
                 <li>Events for CodeSignal Pre-Screen</li>
                 <ul>
                   <li>
+                    <a href="#clientworkflow">Company Client workflow</a>
+                    <ul>
+                      <li><a href="#companyTestSessionCreated">companyTestSessionCreated</a></li>
+                    </ul>
+                  </li>
+                  <li>
                     <a href="#candidateworkflow">Candidate workflow</a>
                     <ul>
                       <li><a href="#preScreenCandidateDeclined">preScreenCandidateDeclined</a></li>
@@ -65,12 +71,6 @@
                     <ul>
                       <li><a href="#preScreenResultNotVerified">preScreenResultNotVerified</a></li>
                       <li><a href="#preScreenResultVerified">preScreenResultVerified</a></li>
-                    </ul>
-                  </li>
-                  <li>
-                    <a href="#clientworkflow">Company Client workflow</a>
-                    <ul>
-                      <li><a href="#companyTestSessionCreated">companyTestSessionCreated</a></li>
                     </ul>
                   </li>
                 </ul>
@@ -325,6 +325,43 @@
           </div>
           <div class="section">
             <h2>Events for CodeSignal Pre-Screen</h2>
+            <div class="subsection">
+              <h3 id="clientworkflow">Company Client workflow</h3>
+              <br />
+              <img
+                alt="Diagram of webhooks triggered on client flow"
+                width="100%"
+                src="../images/client-events.png"
+              />
+            </div>
+            <div class="subsection">
+              <h3 id="companyTestSessionCreated">companyTestSessionCreated</h3>
+              <p>Fired when a test session is created.</p>
+              <div>Request format:</div>
+              <pre><code>{
+   event: 'companyTestSessionCreated',
+   triggeredOn: number,
+   payload: {
+     testSessionId: string,
+     testId: string,
+     testTitle: string,
+     candidateEmail: string,
+     candidateName: string
+   }
+ };</code></pre>
+              <div>Sample request:</div>
+              <pre><code>{
+   event: 'companyTestSessionCreated',
+   triggeredOn: 1553720789347,
+   payload: {
+     testSessionId: 'lehu382hdleh29',
+     testId: 'dhey29hcl28hl28',
+     testTitle: 'Software Engineer intern',
+     candidateEmail: 'jane.doe@gmail.com',
+     candidateName: 'Jane Doe'
+   }
+ };</code></pre>
+            </div>
             <div class="subsection">
               <h3 id="candidateworkflow">Candidate workflow</h3>
               <br />
@@ -629,45 +666,6 @@
   }
 };</code></pre>
             </div>
-
-            <div class="subsection">
-              <h3 id="clientworkflow">Company Client workflow</h3>
-              <br />
-              <img
-                alt="Diagram of webhooks triggered on client flow"
-                width="100%"
-                src="../images/client-events.png"
-              />
-            </div>
-            <div class="subsection">
-              <h3 id="companyTestSessionCreated">companyTestSessionCreated</h3>
-              <p>Fired when a test session is created.</p>
-              <div>Request format:</div>
-              <pre><code>{
-   event: 'companyTestSessionCreated',
-   triggeredOn: number,
-   payload: {
-     testSessionId: string,
-     testId: string,
-     testTitle: string,
-     candidateEmail: string,
-     candidateName: string
-   }
- };</code></pre>
-              <div>Sample request:</div>
-              <pre><code>{
-   event: 'companyTestSessionCreated',
-   triggeredOn: 1553720789347,
-   payload: {
-     testSessionId: 'lehu382hdleh29',
-     testId: 'dhey29hcl28hl28',
-     testTitle: 'Software Engineer intern',
-     candidateEmail: 'jane.doe@gmail.com',
-     candidateName: 'Jane Doe'
-   }
- };</code></pre>
-            </div>
-
             <h2>Events for CodeSignal Pre-Screen Certify</h2>
             <div class="subsection">
               <h3 id="certifyworkflow">Pre-Screen Certify webhooks process flow</h3>

--- a/docs/webhooks/index.html
+++ b/docs/webhooks/index.html
@@ -418,7 +418,11 @@
     duration: number,
     score: number,
     maxScore: number | null | undefined,
-    codingScore?: number | null | undefined,
+    codingScore?: number, // deprecated; use versionedCodingScore instead
+    versionedCodingScore?: {
+      version: 'original' | 'codingScore2023',
+      value: number,
+    },
     externalId?: string
   }
 };</code></pre>
@@ -436,6 +440,10 @@
     score: 900,
     maxScore: 1000,
     codingScore: 820,
+    versionedCodingScore: {
+      version: 'codingScore2023',
+      value: 575
+    },
     plagiarismLevel: 0.5,
     plagiarismLabel: 'medium',
     url: https://app.codesignal.com/test-result/oH3qeBC38oFsf7qB4?accessToken=A7HnBpab4aD7xm7Kp-iPhk2se5Wnxeg7x9GruANLzn
@@ -515,7 +523,11 @@
     duration: number,
     score: number,
     maxScore: number | null | undefined,
-    codingScore?: number | null | undefined,
+    codingScore?: number, // deprecated; use versionedCodingScore instead
+    versionedCodingScore?: {
+      version: 'original' | 'codingScore2023',
+      value: number,
+    },
     externalId?: string
   }
 };</code></pre>
@@ -532,7 +544,11 @@
     duration: 3480000, // 58 minutes
     score: 900,
     maxScore: 1000,
-    codingScore: 820
+    codingScore: 820,
+    versionedCodingScore: {
+      version: 'codingScore2023',
+      value: 575
+    },
   }
 };</code></pre>
             </div>
@@ -552,7 +568,11 @@
     duration: number, // milliseconds
     score: number,
     maxScore: number,
-    codingScore?: number, // Coding Score in range [300, 850], if configured for this assessment
+    codingScore?: number, // deprecated; use versionedCodingScore instead
+    versionedCodingScore?: {
+      version: 'original' | 'codingScore2023',
+      value: number,
+    },
     plagiarismLevel: number,
     plagiarismLabel: 'none' | 'low' | 'medium' | 'high' | '-',
     url: string,
@@ -572,6 +592,10 @@
     score: 900,
     maxScore: 1000,
     codingScore: 820,
+    versionedCodingScore: {
+      version: 'codingScore2023',
+      value: 575
+    },
     plagiarismLevel: 0.5,
     plagiarismLabel: 'medium',
     url: https://app.codesignal.com/test-result/oH3qeBC38oFsf7qB4?accessToken=A7HnBpab4aD7xm7Kp-iPhk2se5Wnxeg7x9GruANLzn
@@ -640,7 +664,11 @@
     duration: number, // milliseconds
     score: number,
     maxScore: number,
-    codingScore?: number, // Coding Score in range [300, 850], if configured for this assessment
+    codingScore?: number, // deprecated; use versionedCodingScore instead
+    versionedCodingScore?: {
+      version: 'original' | 'codingScore2023',
+      value: number,
+    },
     plagiarismLevel: number,
     plagiarismLabel: 'none' | 'low' | 'medium' | 'high' | '-',
     url: string,
@@ -660,6 +688,10 @@
     score: 900,
     maxScore: 1000,
     codingScore: 820,
+    versionedCodingScore: {
+      version: 'codingScore2023',
+      value: 575
+    },
     plagiarismLevel: 0.5,
     plagiarismLabel: 'medium',
     url: https://app.codesignal.com/test-result/oH3qeBC38oFsf7qB4?accessToken=A7HnBpab4aD7xm7Kp-iPhk2se5Wnxeg7x9GruANLzn

--- a/docs/webhooks/index.html
+++ b/docs/webhooks/index.html
@@ -418,7 +418,7 @@
     duration: number,
     score: number,
     maxScore: number | null | undefined,
-    codingScore?: number, // deprecated; use versionedCodingScore instead
+    codingScore?: number | null, // deprecated; use versionedCodingScore instead
     versionedCodingScore?: {
       version: 'original' | 'codingScore2023',
       value: number,
@@ -523,7 +523,7 @@
     duration: number,
     score: number,
     maxScore: number | null | undefined,
-    codingScore?: number, // deprecated; use versionedCodingScore instead
+    codingScore?: number | null, // deprecated; use versionedCodingScore instead
     versionedCodingScore?: {
       version: 'original' | 'codingScore2023',
       value: number,
@@ -568,7 +568,7 @@
     duration: number, // milliseconds
     score: number,
     maxScore: number,
-    codingScore?: number, // deprecated; use versionedCodingScore instead
+    codingScore?: number | null, // deprecated; use versionedCodingScore instead
     versionedCodingScore?: {
       version: 'original' | 'codingScore2023',
       value: number,
@@ -664,7 +664,7 @@
     duration: number, // milliseconds
     score: number,
     maxScore: number,
-    codingScore?: number, // deprecated; use versionedCodingScore instead
+    codingScore?: number | null, // deprecated; use versionedCodingScore instead
     versionedCodingScore?: {
       version: 'original' | 'codingScore2023',
       value: number,


### PR DESCRIPTION
Documentation for https://github.com/CodeSignal/codesignal/issues/29984.
Also closes #45.

**Changes:**

1. Changed subsections order in the Pre-Screens section (#45).
2. Added `versionedCodingScore` fields & examples (https://github.com/CodeSignal/codesignal/issues/29984).