### PR TITLE
Switch `npm run` command to python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A place to put documentation about interacting with our APIs.
 
 ## Running locally
-You can view the documentation site locally by running `npm start` -- you just need to have Python 2 installed on your local machine.
+You can view the documentation site locally by running `npm start` -- you just need to have Python 3 installed on your local machine.
 The start script serves the docs here: http://localhost:8000
 
 Since it's a static site, you can also just open `/docs/index.html` directly in a web browser if you prefer.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "rm -rf docs/graphql/types && graphqldoc --force",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "python -m serve_docs 8000",
+    "start": "python3 -m serve_docs 8000",
     "prettify-webhooks": "prettier --write docs/webhooks"
   },
   "repository": {

--- a/serve_docs.py
+++ b/serve_docs.py
@@ -1,12 +1,11 @@
-import SimpleHTTPServer
+import http.server
 import os
 
 def main():
     pwd = os.getcwd()
-
     try:
         os.chdir("./docs")
-        SimpleHTTPServer.test()
+        http.server.test(http.server.SimpleHTTPRequestHandler)
     finally:
         os.chdir(pwd)
 


### PR DESCRIPTION
Updates docs to use python 3 rather than python 2 on `npm start`.