### PR TITLE
Clarify webhook docs

### DIFF
--- a/docs/graphql/index.css
+++ b/docs/graphql/index.css
@@ -32,11 +32,11 @@ pre {
 }
 
 pre > code {
-    font-family: 'Fira Code', monospace;
+    font-family: 'JetBrains Mono', monospace;
 }
 
 .mono {
-    font-family: 'Fira Code', monospace;
+    font-family: 'JetBrains Mono', monospace;
 }
 
 .page-container {

--- a/docs/graphql/index.html
+++ b/docs/graphql/index.html
@@ -2,10 +2,10 @@
 <html lang="en">
 
 <head>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@300;400;700&family=Work+Sans:wght@400;700&display=auto" rel="stylesheet">
-    <link rel="icon" type="image/png" href="/images/favicon.png" sizes="32x32"/>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+  <link rel="icon" type="image/png" href="/images/favicon.png" sizes="32x32"/>
     <title>CodeSignal GraphQL API</title>
     <meta name="description" content="GraphQL API documentation for the most advanced technical assessment solution on the market."/>
     <link type="text/css" rel="stylesheet" href="index.css" />

--- a/docs/index.css
+++ b/docs/index.css
@@ -44,7 +44,7 @@ h3 {
 }
 
 .header {
-    font-family: 'Fira Code', monospace;
+    font-family: 'JetBrains Mono', monospace;
 }
 
 .header-title {
@@ -71,5 +71,5 @@ h3 {
 .doc-link {
     font-size: 1.3em;
     display: block;
-    font-family: 'Fira Code', monospace;
+    font-family: 'JetBrains Mono', monospace;
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <head>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@300;400;700&family=Work+Sans:wght@400;700&display=auto" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
     <link rel="icon" type="image/png" href="/images/favicon.png" sizes="32x32"/>
     <title>CodeSignal API for Developers</title>
     <meta name="description" content="Developer API documentation for the most advanced technical interview and assessment skills evaluation platform on the market."/>

--- a/docs/webhooks/index.css
+++ b/docs/webhooks/index.css
@@ -38,7 +38,7 @@ pre {
 }
 
 pre > code {
-  font-family: 'Fira Code', monospace;
+  font-family: 'JetBrains Mono', monospace;
 }
 
 li:not(:first-child) {
@@ -46,7 +46,7 @@ li:not(:first-child) {
 }
 
 .mono {
-  font-family: 'Fira Code', monospace;
+  font-family: 'JetBrains Mono', monospace;
 }
 
 .page-container {

--- a/docs/webhooks/index.html
+++ b/docs/webhooks/index.html
@@ -1,12 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@300;400;700&family=Work+Sans:wght@400;700&display=auto"
-      rel="stylesheet"
-    />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
     <link rel="icon" type="image/png" href="/images/favicon.png" sizes="32x32" />
     <title>CodeSignal Webhook API</title>
     <meta
@@ -40,7 +37,7 @@
                 <ul>
                   <li><a href="#auth">Authentication</a></li>
                   <li><a href="#eventhandling">Event handling</a></li>
-                  <li><a href="#retry">Retry policy</a></li>
+                  <li><a href="#retry">Errors and retry policy</a></li>
                   <li><a href="#payloads">Webhook payloads</a></li>
                 </ul>
                 <li>Events for CodeSignal Assessments</li>
@@ -222,13 +219,24 @@
               </p>
             </div>
             <div class="subsection">
-              <h3 id="retry">Retry policy</h3>
+              <h3 id="retry">Errors and retry policy</h3>
               <div>
-                In the event of a failed webhook (due to timeout, a status code other than 200, or
-                network issues), CodeSignal will attempt a maximum of 25 retries with exponential
-                backoff according to the formula below. The number of seconds to wait is relative to
-                the last failed attempt.
-                <pre><code>secondsToWait = failCount^4 + 15 + (random(30) * (failCount + 1))</code></pre>
+                <p>
+                  If CodeSignal receives any response other than a 200 OK from the endpoint,
+                  the endpoint will be marked unhealthy, and CodeSignal will attempt to resend the
+                  event after a delay (up to 25 attempts total).
+                </p>
+                <p>
+                  CodeSignal is looking for a 200 OK response from the endpoint URL in order to continue processing
+                  further events. Do <em>not</em> return 400 errors; they will not be respected and the webhook
+                  will be flagged as unhealthy. Instead, keep error-handling logic internal to your endpoint.
+                </p>
+                <p>
+                  The delay is calculated using an exponential backoff strategy. In other words,
+                  the retry window will be short at first but will increase if the endpoint keeps failing.
+                  The delay between each failure and the next attempt is calculated with the formula below.
+                </p>
+                <pre><code>secondsToWait = (failCount - 1)^4 + 15 + (random(30) * failCount)</code></pre>
               </div>
               <p>
                 Assuming that <span class="mono">random(30)</span> always returns its average of 15,
@@ -238,74 +246,83 @@
               <table>
                 <thead>
                   <tr>
-                    <th align="center">Previous failed attempts</th>
-                    <th align="center">Time since last attempt</th>
-                    <th align="center">Time since first attempt</th>
+                    <th align="center">Total failed attempts</th>
+                    <th align="center">Time until next attempt</th>
+                    <th align="center">Time until next attempt, from first failure</th>
                   </tr>
                 </thead>
                 <tbody>
                   <tr>
-                    <td align="center">0</td>
+                    <td align="center">1</td>
                     <td align="center">30 seconds</td>
                     <td align="center">30 seconds</td>
                   </tr>
                   <tr>
-                    <td align="center">1</td>
+                    <td align="center">2</td>
                     <td align="center">46 seconds</td>
                     <td align="center">1.3 minutes</td>
                   </tr>
                   <tr>
-                    <td align="center">2</td>
+                    <td align="center">3</td>
                     <td align="center">1.2 minutes</td>
                     <td align="center">2.5 minutes</td>
                   </tr>
                   <tr>
-                    <td align="center">3</td>
+                    <td align="center">4</td>
                     <td align="center">2.6 minutes</td>
                     <td align="center">5.1 minutes</td>
                   </tr>
                   <tr>
-                    <td align="center">5</td>
+                    <td align="center">6</td>
                     <td align="center">12.2 minutes</td>
                     <td align="center">23 minutes</td>
                   </tr>
                   <tr>
-                    <td align="center">10</td>
+                    <td align="center">11</td>
                     <td align="center">2.8 hours</td>
                     <td align="center">7.4 hours</td>
                   </tr>
                   <tr>
-                    <td align="center">13</td>
+                    <td align="center">14</td>
                     <td align="center">8 hours</td>
                     <td align="center">1 day</td>
                   </tr>
                   <tr>
-                    <td align="center">15</td>
+                    <td align="center">16</td>
                     <td align="center">14 hours</td>
                     <td align="center">2.1 days</td>
                   </tr>
                   <tr>
                     <td align="center">24</td>
-                    <td align="center">3.8 days</td>
-                    <td align="center">20.5 days</td>
+                    <td align="center">3.2 days</td>
+                    <td align="center">16.6 days</td>
+                  </tr>
+                  <tr>
+                    <td align="center">25</td>
+                    <td align="center">n/a</td>
+                    <td align="center">n/a</td>
                   </tr>
                 </tbody>
               </table>
               <p>
                 After the first few retries CodeSignal will also send an email notification to the
                 owner emails associated with the webhook, if any. To make sure we don't spam you,
-                CodeSignal will send at most one email a day for every webhook. This means that you
-                will generally be notified about the 5th fail, the 14th fail, and every fail
-                starting from the 16th.
+                CodeSignal will only send emails for each webhook after the 5th failure, the 14th failure,
+                and every failure starting from the 16th.
               </p>
               <p>
                 When a webhook is unhealthy, events will be queued in the order they were triggered,
-                and the queue will not be flushed until the first event in the queue is able to be
+                and the queue will not be flushed until the first event in the queue can be
                 processed successfully (by receiving a 200 OK response from the endpoint URL). If
                 you are able to identify and resolve the issue with the endpoint URL, you can open
                 the webhook settings modal, then test and save the fixed webhook in order to mark it
                 as healthy again. Once it is marked as healthy, the webhook will immediately flush
                 its queue of pending events.
+              </p>
+              <p>
+                After 25 consecutive failed delivery attempts, the webhook will be disabled and the
+                events queue will be cleared. You can re-enable the webhook after updating the endpoint
+                to return a valid 200 OK response.
               </p>
             </div>
             <div class="subsection">


### PR DESCRIPTION
This PR updates the retry policy documentation for webhooks to be more clear.

Previously, the docs/math relied on using the pre-increment count (i.e., "fail count" would be 0 on the first failure), which I think it is a little confusing. I updated the docs to consistently describe the delay policy in terms of post-increment failure count (i.e., after the first failure the fail count is 1).

Also, the final entry in the example table (where "fail count" is equal to 25) was impossible since the 25th failure would be the final delivery attempt. If we want to show the last delay, we should show the delay after the 24th failure instead.

**Side change:** I also updated the monospace/code font from Fira Code to JetBrains Mono to match design system updates.